### PR TITLE
new_release: use clear word update payload uploaded

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -21,7 +21,7 @@ The release of Flatcar Container Linux <VERSION> [<VERSION> ...] is planned for 
 - [ ] Release notes / announcements added to Go/No Go doc from `container/image_changes` job by selecting `Timestamps: None` ()
 - [ ] QA: check diff for image file list, packages, and image size in the image job output ()
 - [ ] Matrix Go/No Go meeting (inc. release notes review) ()
-- [ ] Update payload signed/published ()
+- [ ] Update payload signed/uploaded ()
 - [ ] `scripts` release created on GitHub ()
 - [ ] Release job `container/release` ran ()
 - [ ] Images uploaded with `copy-to-origin.sh` ()


### PR DESCRIPTION
If we say `Update payload published`, then that sentence can be confusing, because `published` could actually mean the final step in Nebraska, i.e. `Release package published in Nebraska`.
So change it to `Update payload uploaded`.
