### PR TITLE
template/release: add a reminder for CAPI images

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -6,7 +6,7 @@ labels: "kind/release"
 assignees: '@sayanchowdhury'
 ---
 
-## Release Flatcar Container Linux <Alpha-VERSION> [<Beta-VERSION>] [>Stable-VERSION>]
+## Release Flatcar Container Linux <Alpha-VERSION> [<Beta-VERSION>] [<Stable-VERSION>]
   
 The release of Flatcar Container Linux <VERSION> [<VERSION> ...] is planned for <MONTH> <DAY>, <YEAR>. 
 
@@ -28,6 +28,8 @@ The release of Flatcar Container Linux <VERSION> [<VERSION> ...] is planned for 
 - [ ] Azure offer updated & publishing started ()
 - [ ] Azure Go Live ()
 - [ ] GCP offers updated ()
+- [ ] For new Stable: Manually run `./azure-sig.sh` to create new Shared Community Gallery Images
+- [ ] For new Stable: build and provide images for supported Cluster API providers ()
 - [ ] Symlink to "current" updated with `set-symlink.sh` ()
 - [ ] Website updated with `./update-flatcar-versions.sh` and PR merged ()
 - [ ] Release package published in Nebraska ()


### PR DESCRIPTION
Don't know really if it's the good place - but since we don't have (yet?) automation around this, than can be nice to at least have a reminder to build and provide Flatcar CAPI images for supported cloud providers? See also: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/1444#issuecomment-1451501878

<hr>

It's a proposal, feel free to suggest other way