### PR TITLE
.github: Add issue template for public security issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_issue.md
+++ b/.github/ISSUE_TEMPLATE/security_issue.md
@@ -1,0 +1,16 @@
+---
+name: Security Issue
+about: Creating a public security issue. For embargoed issues, private disclosure or in case of doubt: contact security@flatcar-linux.org
+title: "update: <software>"
+labels: ["advisory", "security"]
+assignees: ''
+---
+
+**Name**: <software>
+**CVEs**: [<CVE-ID>](https://nvd.nist.gov/vuln/detail/<CVE-ID>)
+**CVSSs**: <score>
+**Action Needed**: TBD
+
+**Summary**: <CVE description>
+
+**refmap.gentoo**: TBD


### PR DESCRIPTION
This template is used by maintainers and users to track security issues that are already public.
For embargoed issues and newly-reported private issues the template hints at using the security e-mail contact.
