### PR TITLE
Revert "azure: remove "go live" action"

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -66,6 +66,7 @@ Owner:
 
 - A. Azure
     - [ ] Offers updated and started publishing.
+    - [ ] Sent the offers to publish to Live.
 
 - B. GCP
     - [ ] Offer deployment package uploaded to Google Bucket & submit for verification.


### PR DESCRIPTION
This reverts commit 58421270dda944e448dc306f85469da9e3555c79.

---

Finally, it was necessary this time... Let's keep it around.