### PR TITLE
security_issue: update default CVE URL to cve.org

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_issue.md
+++ b/.github/ISSUE_TEMPLATE/security_issue.md
@@ -7,7 +7,7 @@ assignees: ''
 ---
 
 **Name**: <software>
-**CVEs**: [<CVE-ID>](https://nvd.nist.gov/vuln/detail/<CVE-ID>)
+**CVEs**: [<CVE-ID>](https://www.cve.org/CVERecord?id=<CVE-ID>)
 **CVSSs**: <score>
 **Action Needed**: TBD
 


### PR DESCRIPTION
Since many months CVE entries of [nvd.nist.gov](https://nvd.nist.gov) have been partly not up-to-date regarding CVSS scores.
On the other hand, corresponding entries on [cve.org](https://www.cve.org/) seem indeed updated with correct scores that are located under their `CISA-ADP`/`CVSS` section.

Let's update the default CVE URL of advisories to `cve.org` for better tracking of CVSS scores.