### PR TITLE
release: invert release job and release notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release.md
+++ b/.github/ISSUE_TEMPLATE/new_release.md
@@ -47,8 +47,8 @@ Owner:
 
 Owner:
 
-- [ ] A. Created the Release Notes on the `scripts` repo for the respective tags on GitHub as GitHub Releases.
-- [ ] B. Ran the `container/release` Release job.
+- [ ] A. Ran the `container/release` Release job.
+- [ ] B. Created the Release Notes on the `scripts` repo for the respective tags on GitHub as GitHub Releases.
 - [ ] C. Images uploaded with `copy-to-origin.sh`.
 - [ ] D. Symlink to "current" updated with `set-symlink.sh`.
 - [ ] E. Website updated with `./update-flatcar-versions.sh` and PR merged.


### PR DESCRIPTION
It makes sense to first trigger the release job (as it now takes ages) and to proceed in parallel to publish the release notes on Github.

---

It's not mandatory to strictly follow the order of the items but it can help to remind to first trigger the `container/release` job.  